### PR TITLE
Added possibility to sort by reductions increment, added node load average stats, header format cleanup, other small changes

### DIFF
--- a/src/entop.hrl
+++ b/src/entop.hrl
@@ -16,5 +16,5 @@
 %% Records 
 -record(state, { callback = entop_format, remote_module = entop_collector,
 		 columns, cbstate, node, otp_version, erts_version, os_fam, os,
-		 os_version, node_flags, interval = 1000, reverse_sort = true,
-		 sort = 1, connected = false }).
+		 os_version, node_flags, interval = 5000, reverse_sort = true,
+		 sort = 1, connected = false, last_reductions = []}).

--- a/src/entop_collector.erl
+++ b/src/entop_collector.erl
@@ -31,7 +31,8 @@ get_data() ->
 		      {reduction_count, erlang:statistics(reductions)},
 		      {process_memory_used, erlang:memory(processes_used)},
 		      {process_memory_total, erlang:memory(processes)},
-		      {memory, erlang:memory([system, atom, atom_used, binary, code, ets])}
+		      {memory, erlang:memory([system, atom, atom_used, binary, code, ets])},
+		      {cpu, [{avg1, cpu_sup:avg1() / 256}, {avg5, cpu_sup:avg5() / 256}, {avg15, cpu_sup:avg15() / 256}]}
 		     ],
     Self = self(),
     ProcessesProplist =  [ [ {pid,erlang:pid_to_list(P)} | process_info_items(P) ] ||
@@ -48,4 +49,8 @@ process_info_items(P) ->
                             message_queue_len,
                             heap_size,
                             stack_size,
-                            total_heap_size]).
+                            total_heap_size,
+                            dictionary,
+                            initial_call,
+                            current_function,
+                            status]).

--- a/src/entop_format.erl
+++ b/src/entop_format.erl
@@ -20,7 +20,7 @@
 -include_lib("cecho/include/cecho.hrl").
 
 %% Module API
--export([init/1, header/2, row/2]).
+-export([init/1, header/2, row/3, row_reductions/1]).
 
 %% Records
 -record(state, { node = undefined, cache = [] }).
@@ -38,31 +38,39 @@
 %% Module API
 %% =============================================================================
 init(Node) ->
-    Columns = [{"Pid", 12, [{align, right}]},
-	       {"Registered Name", 20, []},
-	       {"Reductions", 12, []},
-	       {"MQueue", 6, []},
-	       {"HSize", 6, []},
-	       {"SSize", 6, []},
-	       {"HTot", 6, []}],
-    {ok, {Columns, 3}, #state{ node = Node }}.
+    Columns = [
+            {"Pid", 16, [{align, left}]},
+            {"Process", 30, [{align, left}]},
+            {"Current Function", 30, [{align, left}]},
+            {"Status", 8, [{align, left}]},
+            {"Reductions", 13, [{align, right}]},
+            {"Reductions+", 13, [{align, right}]},
+            {"Message Queue", 14, [{align, right}]},
+            {"Stack Size", 11, [{align, right}]},
+            {"Heap Size", 12, [{align, right}]}
+        ],
+    {ok, {Columns, 6}, #state{ node = Node }}.
 
 %% Header Callback
 header(SystemInfo, State) ->
     Uptime = millis2uptimestr(element(1, proplists:get_value(uptime, SystemInfo, 0))),
     LocalTime = local2str(element(2, proplists:get_value(local_time, SystemInfo))),
     PingTime = element(1,timer:tc(net_adm, ping, [State#state.node])) div 1000,
-    Row1 = io_lib:format("Time: local time ~s, up for ~s, ~pms latency, ",
-			 [LocalTime, Uptime, PingTime]),
+    CPUInfo = proplists:get_value(cpu, SystemInfo, []),
+    CPUAvg1 = proplists:get_value(avg1, CPUInfo, 0.0),
+    CPUAvg5 = proplists:get_value(avg5, CPUInfo, 0.0),
+    CPUAvg15 = proplists:get_value(avg15, CPUInfo, 0.0),
+    Row1 = io_lib:format("Time: ~s, up for ~s, ~pms latency, load average: ~.2f, ~.2f, ~5.2f",
+			 [LocalTime, Uptime, PingTime, CPUAvg1, CPUAvg5, CPUAvg15]),
 
     PTotal = proplists:get_value(process_count, SystemInfo),
     RQueue = proplists:get_value(run_queue, SystemInfo),
     RedTotal = element(2,proplists:get_value(reduction_count, SystemInfo)),
-    PMemUsed = proplists:get_value(process_memory_used, SystemInfo),
-    PMemTotal = proplists:get_value(process_memory_total, SystemInfo),
-    Row2 = io_lib:format("Processes: total ~p (RQ ~p) at ~p RpI using ~s (~s allocated)",
-			 [PTotal, RQueue, RedTotal, mem2str(PMemUsed), mem2str(PMemTotal)]),
+    Row2 = io_lib:format("Processes: ~6w,  Run Queue: ~5w,  Reductions: ~9w~n",
+			 [PTotal, RQueue, RedTotal]),
 
+    PMemUsed = mem2str(proplists:get_value(process_memory_used, SystemInfo)),
+    PMemTotal = mem2str(proplists:get_value(process_memory_total, SystemInfo)),
     MemInfo = proplists:get_value(memory, SystemInfo),
     SystemMem = mem2str(proplists:get_value(system, MemInfo)),
     AtomMem = mem2str(proplists:get_value(atom, MemInfo)),
@@ -70,32 +78,46 @@ header(SystemInfo, State) ->
     BinMem = mem2str(proplists:get_value(binary, MemInfo)),
     CodeMem = mem2str(proplists:get_value(code, MemInfo)),
     EtsMem = mem2str(proplists:get_value(ets, MemInfo)),
-    Row3 = io_lib:format("Memory: Sys ~s, Atom ~s/~s, Bin ~s, Code ~s, Ets ~s",
-			 [SystemMem, AtomUsedMem, AtomMem, BinMem, CodeMem, EtsMem]),
+    Row3 = io_lib:format("Memory: ~s total, ~s allocated (~s system, ~s/~s atom, ~s binary, ~s code, ~s ets)",
+			 [PMemTotal, PMemUsed, SystemMem, AtomUsedMem, AtomMem, BinMem, CodeMem, EtsMem]),
     Row4 = "",
     {ok, [ lists:flatten(Row) || Row <- [Row1, Row2, Row3, Row4] ], State}.
 
 %% Column Specific Callbacks
-row([{pid,_}|undefined], State) ->
+row([{pid,_}|undefined], _LastReductions, State) ->
     {ok, skip, State};
-row(ProcessInfo, State) ->
+row(ProcessInfo, LastReductions, State) ->
     Pid = proplists:get_value(pid, ProcessInfo),
-    RegName = case proplists:get_value(registered_name, ProcessInfo) of
-		  [] ->
-		      "-";
-		  Name ->
-		      atom_to_list(Name)
-	      end,
+    ProcessName = proc_name(ProcessInfo),
+    CurrentFunction = proplists:get_value(current_function, ProcessInfo),
     Reductions = proplists:get_value(reductions, ProcessInfo, 0),
+    ReductionsDiff = Reductions - LastReductions,
     Queue = proplists:get_value(message_queue_len, ProcessInfo, 0),
-    Heap = proplists:get_value(heap_size, ProcessInfo, 0),
-    Stack = proplists:get_value(stack_size, ProcessInfo, 0),
-    HeapTot = proplists:get_value(total_heap_size, ProcessInfo, 0),
-    {ok, {Pid, RegName, Reductions, Queue, Heap, Stack, HeapTot}, State}.
+    StackSize = proplists:get_value(stack_size, ProcessInfo, 0),
+    TotalHeapSize = proplists:get_value(total_heap_size, ProcessInfo, 0),
+    Status = proplists:get_value(status, ProcessInfo),
+    {ok, {Pid, ProcessName, CurrentFunction, Status, Reductions, ReductionsDiff, Queue, StackSize, TotalHeapSize}, State}.
+
+row_reductions({Pid, _, _, _, Reductions, _, _, _, _} = _Row) ->
+	{Pid, Reductions}.
+
+proc_name(ProcessInfo) ->
+    case proplists:get_value(registered_name, ProcessInfo, []) of
+        [] -> initial_call(ProcessInfo);
+        Name -> Name
+    end.
+
+initial_call(ProcessInfo) ->
+    ProcessDict = proplists:get_value('dictionary', ProcessInfo, []),
+    case proplists:get_value('$initial_call', ProcessDict, []) of
+        [] -> proplists:get_value(initial_call, ProcessInfo);
+        Call -> Call
+    end.
 
 mem2str(Mem) ->
-    if Mem > ?GIB -> io_lib:format("~.1fm",[Mem/?MIB]);
-       Mem > ?KIB -> io_lib:format("~.1fk",[Mem/?KIB]);
+    if Mem > ?GIB -> io_lib:format("~.1fG",[Mem/?GIB]);
+       Mem > ?MIB -> io_lib:format("~.1fM",[Mem/?MIB]);
+       Mem > ?KIB -> io_lib:format("~.1fK",[Mem/?KIB]);
        Mem >= 0 -> io_lib:format("~.1fb",[Mem/1.0])
     end.
 


### PR DESCRIPTION
Entop has been extended with information about:
- number of reductions for the processes since the last data collection run, this way we can see top grossing processes consuming reductions
- name of the currently running function
- better detection of the name of a processes (if we fail to find name of the process, try to show name of the function which started the process)
- cpu load average stats

Plus other small corrections, cleanups.
