### PR TITLE
Don't silently truncate numeric values

### DIFF
--- a/src/entop_format.erl
+++ b/src/entop_format.erl
@@ -40,11 +40,11 @@
 init(Node) ->
     Columns = [{"Pid", 12, [{align, right}]},
 	       {"Registered Name", 20, []},
-	       {"Reductions", 12, []},
-	       {"MQueue", 6, []},
-	       {"HSize", 6, []},
-	       {"SSize", 6, []},
-	       {"HTot", 6, []}],
+	       {"Reductions", 12, [no_silent_truncation]},
+	       {"MQueue", 6, [no_silent_truncation]},
+	       {"HSize", 6, [no_silent_truncation]},
+	       {"SSize", 6, [no_silent_truncation]},
+	       {"HTot", 6, [no_silent_truncation]}],
     {ok, {Columns, 3}, #state{ node = Node }}.
 
 %% Header Callback

--- a/src/entop_view.erl
+++ b/src/entop_view.erl
@@ -244,10 +244,13 @@ update_row([RowColValue|Rest], [{_,Width,Options}|RestColumns], LineNumber, Offs
 		   true ->
 			lists:flatten(io_lib:format("~1000p",[RowColValue]))
 		end,
-    Aligned = case proplists:get_value(align, Options) of
-		  right ->
+    Aligned = case {proplists:get_value(align, Options),
+		    proplists:get_value(no_silent_truncation, Options, false)} of
+		  {_, true} when length(StrColVal) > Width ->
+		      lists:duplicate(Width, $*);
+		  {right, _} ->
 		      string:right(StrColVal, Width);
-		  _ ->
+		  {_, _} ->
 		      string:left(StrColVal, Width)
 	      end,
     cecho:mvaddstr(LineNumber, Offset, Aligned),


### PR DESCRIPTION
If e.g. the message queue length for a process is greater than 999999,
entop would silently truncate it and only display the first 6 digits.
This patch makes it fill the field with asterisks instead, like
io:format does when a value doesn't fit its field width.
