### PR TITLE
Handle node names of the form app@127.0.0.1 and support column resizing

### DIFF
--- a/src/entop.erl
+++ b/src/entop.erl
@@ -110,7 +110,7 @@ name_type (Node) when is_list(Node) ->
         end,
       rand_seed(),
       R = rand_uniform(1000000),
-      EntopName = list_to_atom("entop-" ++ integer_to_list(R) ++ "-" ++ N),
+      EntopName = list_to_atom("entop-" ++ integer_to_list(R) ++ "-" ++ N ++ "@" ++ H),
       {ok,[EntopName,T]}
   end.
 

--- a/src/entop_view.erl
+++ b/src/entop_view.erl
@@ -187,12 +187,13 @@ update_screen(Time, HeaderData, RowDataList, State) ->
               end, 1, Headers),
   {RowList, State2} = process_row_data(RowDataList, State1),
   SortedRowList = sort(RowList, State),
-  {Y, _} = cecho:getmaxyx(),
+  {Y, X} = cecho:getmaxyx(),
+  {ok, Columns} = (State#state.callback):resize(X, State2#state.cbstate),
   StartY = (Y-(Y-8)),
   lists:foreach(fun(N) -> cecho:move(N, 0), cecho:hline($ , ?MAX_HLINE) end, lists:seq(StartY, Y)),
-  update_rows(SortedRowList, State2#state.columns, StartY, Y),
+  update_rows(SortedRowList, Columns, StartY, Y),
   cecho:refresh(),
-  State2.
+  State2#state{columns=Columns}.
 
 draw_title_bar(State) ->
   cecho:move(7, 0),


### PR DESCRIPTION
Here's a couple enhancements I came up with after using entop to monitor some rebar3 generated erlang release nodes.

The first commit appends whatever the 'host' component of the target node was to the end of the node string.

The second commit resizes columns if the window is big enough, or changes size.