### PR TITLE
Support empty cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ then you can copy the entop script to a bin directory
 ## Usage
 To run entop make sure you have Erlang installed, cecho and entop libraries installed, and that the script is in your path.
 
-    Usage: ./entop <TARGETNODE> <COOKIE>
+    Usage: ./entop <TARGETNODE> [<COOKIE>]
 
 ### An example of how you run entop:
 

--- a/entop
+++ b/entop
@@ -49,7 +49,7 @@ else
 fi
 
 erl -noinput -hidden $PATHS +A 20 +Bc \
-    -eval "entop:main(['${TARGETNODE}','${COOKIE}'])" $@
+    -eval "entop:main(['${TARGETNODE}','${COOKIE}'])." "$@"
 
 CODE=$?
 if [[ $CODE -eq 101 ]]; then

--- a/entop
+++ b/entop
@@ -26,11 +26,9 @@
 ##==============================================================================
 
 ## Shell script for running entop. See the function usage() for instructions.
-TARGETNODE=
-COOKIE=
 
 function usage() {
-    echo -e "Usage: ./entop <TARGETNODE> <COOKIE>"
+    echo -e "Usage: ./entop <TARGETNODE> [<COOKIE>]"
 }
 
 if [[ $# -lt 1 ]]; then
@@ -41,7 +39,7 @@ fi
 TARGETNODE=$1
 shift
 
-COOKIE=$1
+COOKIE=${1-undefined}
 shift
 
 if [[ -d _build ]] ; then


### PR DESCRIPTION
This correctly handles case when no cookie is given and an empty cookie.
Default cookie (CookieIn is undefined in entop:main/1)
$ entop NODE 
Empty cookie (CookieIn is an empty atom '' in entop:main/1)
$ entop NODE '' 
